### PR TITLE
update googleads-python-lib to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## 1.1.1
+*2017-06-30* 
+
+- Updated googleads-python-lib to 6.0.0
+
+## 1.1.0
+*2017-06-07* 
+
+- Updated googleads-python-lib to 5.6.0 and use AdWords API version v201705
+
 ## 1.0.0 
 *2017-02-24* 
 
 - Initial version
-
-## 1.1.0 
-*2017-06-07* 
-
-- Updated googleads-python-lib to 5.6.0 and use AdWords API version v201705

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google AdWords Performance Downloader
 
-A Python script for downloading performance data and account structure from an [MCC account](https://adwords.google.com/home/tools/manager-accounts/) using the Google Adwords API ([v201702](https://developers.google.com/adwords/api/docs/reference/#v201702)) to local files. 
+A Python script for downloading performance data and account structure from an [MCC account](https://adwords.google.com/home/tools/manager-accounts/) using the Google Adwords API ([v201705](https://developers.google.com/adwords/api/docs/reference/#v201705)) to local files.
 
 ## Resulting data
 By default, it creates two data sets:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description="Downloads data from the Google Adwords Api to local files",
 
     install_requires=[
-        'googleads==5.6.0',
+        'googleads==6.0.0',
         'click>=6.0'
     ],
 


### PR DESCRIPTION
This PR updates the googleads-python-lib to version 6.0.0. API version is still 201705 (current one).