### PR TITLE
Fix bug with unique ad identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 __pycache__
 .idea
+.vscode
 .venv/
 build
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 .idea
 .venv/
+build
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0 (2019-07-05)
+
+- Compatible with specifications: a unique identifier is an Ad ID + Ad Group ID.
+
 ## 3.0.0 (2019-04-13)
 
 - Change MARA_XXX variables to functions to delay importing of imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 4.0.0 (2019-07-05)
 
 - Compatible with specifications: a unique identifier is an Ad ID + Ad Group ID.
+- Add option to ignore downloading of data related to removed campaigns
+
+**required changes**
+
+- The file format changed to `v5`. Adapt etl scripts that process the output data.
+  - Ad ID no longer unique in any files
+  - Ad performance datasets now include Ad Group Id
 
 ## 3.0.0 (2019-04-13)
 

--- a/google_ads_downloader/config.py
+++ b/google_ads_downloader/config.py
@@ -62,3 +62,8 @@ def max_retries() -> int:
 def retry_backoff_factor() -> int:
     """How many seconds to wait between retries (is multiplied with retry count)"""
     return 5
+
+
+def ignore_removed_campaigns() -> bool:
+    """Whether to ignore campaigns with status 'REMOVED'"""
+    return False

--- a/google_ads_downloader/config.py
+++ b/google_ads_downloader/config.py
@@ -51,7 +51,7 @@ def redownload_window() -> str:
 
 def output_file_version() -> str:
     """A suffix that is added to output files, denoting a version of the data format"""
-    return 'v4'
+    return 'v5'
 
 
 def max_retries() -> int:

--- a/google_ads_downloader/downloader.py
+++ b/google_ads_downloader/downloader.py
@@ -103,7 +103,7 @@ def download_data_sets(api_client: AdWordsApiClient):
     """
     download_performance(api_client,
                          PerformanceReportType.AD_PERFORMANCE_REPORT,
-                         fields=['Date', 'Id', 'Device', 'AdNetworkType2',
+                         fields=['Date', 'Id', 'AdGroupId', 'Device', 'AdNetworkType2',
                                  'ActiveViewImpressions', 'AveragePosition',
                                  'Clicks', 'Conversions', 'ConversionValue',
                                  'Cost', 'Impressions'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='google-ads-performance-downloader',
-    version='3.0.0',
+    version='4.0.0',
     description="Downloads data from the Google Adwords Api to local files",
 
     install_requires=[


### PR DESCRIPTION
Don't use a dictionary for the campaign tree, because ads would be overwritten, plus it's slower and consumes more memory than a list, which, according to Google, would be valid, with unique Ad ID + Ad Group ID combinations.

A bit of refactoring (simplify some code) was also included.